### PR TITLE
hw-01

### DIFF
--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -4,7 +4,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.*
-import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.orders.repository.OrderRepository
 import ru.quipy.payments.logic.OrderPayer
 import java.util.*
@@ -19,8 +18,6 @@ class APIController {
 
     @Autowired
     private lateinit var orderPayer: OrderPayer
-
-    private var rateLimiter = SlidingWindowRateLimiter(10, java.time.Duration.ofSeconds(1))
 
     @PostMapping("/users")
     fun createUser(@RequestBody req: CreateUserRequest): User {
@@ -65,7 +62,6 @@ class APIController {
             it
         } ?: throw IllegalArgumentException("No such order $orderId")
 
-        rateLimiter.tickBlocking()
         val createdAt = orderPayer.processPayment(orderId, order.price, paymentId, deadline)
         return PaymentSubmissionDto(createdAt, paymentId)
     }

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -4,6 +4,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.*
+import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.orders.repository.OrderRepository
 import ru.quipy.payments.logic.OrderPayer
 import java.util.*
@@ -18,6 +19,8 @@ class APIController {
 
     @Autowired
     private lateinit var orderPayer: OrderPayer
+
+    private var rateLimiter = SlidingWindowRateLimiter(10, java.time.Duration.ofSeconds(1))
 
     @PostMapping("/users")
     fun createUser(@RequestBody req: CreateUserRequest): User {
@@ -62,7 +65,7 @@ class APIController {
             it
         } ?: throw IllegalArgumentException("No such order $orderId")
 
-
+        rateLimiter.tickBlocking()
         val createdAt = orderPayer.processPayment(orderId, order.price, paymentId, deadline)
         return PaymentSubmissionDto(createdAt, paymentId)
     }

--- a/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
@@ -35,7 +35,7 @@ class SlidingWindowRateLimiter(
 
     fun tickBlocking() {
         while (!tick()) {
-            Thread.sleep(10)
+            Thread.sleep(12)
         }
     }
 

--- a/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
@@ -10,8 +10,6 @@ import java.time.Duration
 import java.util.concurrent.Executors
 import java.util.concurrent.PriorityBlockingQueue
 import java.util.concurrent.atomic.AtomicLong
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
 
 class SlidingWindowRateLimiter(
     private val rate: Long,
@@ -35,7 +33,15 @@ class SlidingWindowRateLimiter(
 
     fun tickBlocking() {
         while (!tick()) {
-            Thread.sleep(12)
+            Thread.sleep(10)
+        }
+    }
+
+    fun tickBlocking(timeout: Duration) {
+        var curWaiting: Duration = Duration.ofSeconds(0)
+        while (!tick() && curWaiting < timeout) {
+            Thread.sleep(10)
+            curWaiting = curWaiting.plusMillis(10)
         }
     }
 

--- a/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.time.Clock
 import java.time.Duration
 import java.util.concurrent.Executors
 import java.util.concurrent.PriorityBlockingQueue
@@ -38,10 +39,9 @@ class SlidingWindowRateLimiter(
     }
 
     fun tickBlocking(timeout: Duration) {
-        var curWaiting: Duration = Duration.ofSeconds(0)
-        while (!tick() && curWaiting < timeout) {
+        val deadline = Clock.systemUTC().instant().plus(timeout)
+        while (!tick() && Clock.systemUTC().instant().isBefore(deadline)) {
             Thread.sleep(10)
-            curWaiting = curWaiting.plusMillis(10)
         }
     }
 

--- a/test-local-run.http
+++ b/test-local-run.http
@@ -5,8 +5,8 @@ Content-Type: application/json
 {
   "serviceName": "{{serviceName}}",
   "token": "{{token}}",
-  "ratePerSecond": 1,
-  "testCount": 100,
+  "ratePerSecond": 11,
+  "testCount": 1200,
   "processingTimeMillis": 80000
 }
 


### PR DESCRIPTION
Ход размышлений:

1. Попытка реализовать свою очередь. Хорошо по прибыли, но мало успешных тестов
2. Использовали FixedWindowRateLimiter с разными rate значениями. Сначала просто tick(), потом tickBlocking(). Показался неэффективным
3. Перешли на SlidingWindowRateLimiter. Уже получше: поигравшись с rate и millisec, дошли до 93% income и >96.9% suc percent (rate=10 millisec=10)
4. Изменение millisec=12 позволило поднять suc percent до стабильного 100% при сохранении income на уровне 93%
5. При повторных тестах локально и удаленно получали результаты и хуже, но все вписывались в income >= 93%, succ percent >= 97%
6. Добавление метода tickBlocking с ожиданием 50 секунд, использование prs из аккаунта