### PR TITLE
Hw 08

### DIFF
--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -40,8 +40,8 @@ class OrderPayer {
     @PostConstruct
     private fun initialize() {
         paymentExecutor = ThreadPoolExecutor(
-            16,
-            16,
+            50,
+            50,
             0L,
             TimeUnit.MILLISECONDS,
             LinkedBlockingQueue(10_000),

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -44,8 +44,8 @@ class PaymentExternalSystemAdapterImpl(
     private val semaphore = Semaphore(parallelRequests, true)
 
     private val client = OkHttpClient.Builder()
-        .connectTimeout(Duration.ofMillis(200))
-        .readTimeout(Duration.ofMillis(2000))
+        .connectTimeout(Duration.ofMillis(100))
+        .readTimeout(Duration.ofMillis(1000))
         .build()
 
     private val requestLatency = DistributionSummary.builder("request_latency").publishPercentiles( 0.9, 0.95, 0.99).register(promRegistry)


### PR DESCRIPTION
До: http://77.234.215.138:33000/d/KVr-Vmpnz/services-statistic?orgId=1&from=2025-11-14T14:45:23.345Z&to=2025-11-14T14:47:29.491Z&timezone=browser&var-service=M3401-9&refresh=5s

После: http://77.234.215.138:33000/d/KVr-Vmpnz/services-statistic?orgId=1&from=2025-11-14T14:56:46.858Z&to=2025-11-14T14:58:17.424Z&timezone=browser&var-service=M3401-9&refresh=5s

Среднее время обработки = 0,5 секунд. В таком случае, "производительность" одного потока равна 1 запрос / 0,5 секунд = 2 запроса в секунду. Нам нужно выдерживать 100 запросов в секунду, а значит требуется 100 / 2 = 50 потоков.
Также 90% запросов выполняются за 1000 мс, поэтому readTimeout установлен на такое значение
<img width="672" height="394" alt="image" src="https://github.com/user-attachments/assets/3429134c-84da-4669-be1e-a2660df8e709" />
