### PR TITLE
Hw 10

### DIFF
--- a/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
@@ -32,16 +32,16 @@ class SlidingWindowRateLimiter(
         }
     }
 
-    fun tickBlocking() {
+    suspend fun tickBlocking() {
         while (!tick()) {
-            Thread.sleep(10)
+            delay(10)
         }
     }
 
-    fun tickBlocking(timeout: Duration) {
+    suspend fun tickBlocking(timeout: Duration) {
         val deadline = Clock.systemUTC().instant().plus(timeout)
         while (!tick() && Clock.systemUTC().instant().isBefore(deadline)) {
-            Thread.sleep(10)
+            delay(10)
         }
     }
 

--- a/src/main/kotlin/ru/quipy/payments/config/PaymentAccountsConfig.kt
+++ b/src/main/kotlin/ru/quipy/payments/config/PaymentAccountsConfig.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -36,6 +37,9 @@ class PaymentAccountsConfig {
     @Value("#{'\${payment.accounts}'.split(',')}")
     lateinit var allowedAccounts: List<String>
 
+    @Autowired
+    lateinit var paymentEventWriter: PaymentEventWriter
+
     @Bean
     fun accountAdapters(paymentService: EventSourcingService<UUID, PaymentAggregate, PaymentAggregateState>, promRegistry: MeterRegistry): List<PaymentExternalSystemAdapter> {
         val request = HttpRequest.newBuilder()
@@ -59,7 +63,8 @@ class PaymentAccountsConfig {
                     paymentService,
                     paymentProviderHostPort,
                     token,
-                    promRegistry
+                    paymentEventWriter,
+                    promRegistry,
                 )
             }
     }

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -12,7 +12,6 @@ import ru.quipy.common.utils.CallerBlockingRejectedExecutionHandler
 import ru.quipy.common.utils.LeakingBucketRateLimiter
 import ru.quipy.common.utils.NamedThreadFactory
 import ru.quipy.common.utils.RateLimiter
-import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
 import java.time.Duration
@@ -39,17 +38,14 @@ class OrderPayer {
 
     private lateinit var paymentExecutor: ThreadPoolExecutor
     private lateinit var executorScope: CoroutineScope
-    private var averageProcessingTime: Long = 0
-    private var rateLimitPerSec: Int = 0
-    private var parallelRequests: Int = 0
 
     private lateinit var rateLimiter: RateLimiter
 
     @PostConstruct
     private fun initialize() {
         paymentExecutor = ThreadPoolExecutor(
-            50,
-            50,
+            200,
+            200,
             0L,
             TimeUnit.MILLISECONDS,
             LinkedBlockingQueue(10_000),
@@ -58,16 +54,12 @@ class OrderPayer {
         )
         paymentExecutor.prestartAllCoreThreads()
         executorScope = CoroutineScope(paymentExecutor.asCoroutineDispatcher())
-        averageProcessingTime = paymentService.getAllAccountProperties()
-            .maxOf { properties -> properties.averageProcessingTime.toMillis() }
-        rateLimitPerSec = paymentService.getAllAccountProperties()
-            .minOf { properties -> properties.rateLimitPerSec }
-        parallelRequests = paymentService.getAllAccountProperties()
-            .minOf { properties -> properties.parallelRequests }
-        rateLimiter = SlidingWindowRateLimiter(
-            5000,
-            Duration.ofSeconds(1)
-        )
+        rateLimiter =
+            LeakingBucketRateLimiter(
+                rate = 5000,
+                window = Duration.ofMillis(1000),
+                bucketSize = 5000
+            )
     }
 
     suspend fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -33,6 +33,9 @@ class OrderPayer {
     @Autowired
     private lateinit var paymentService: PaymentService
 
+    @Autowired
+    lateinit var paymentEventWriter: PaymentEventWriter
+
     private lateinit var paymentExecutor: ThreadPoolExecutor
     private lateinit var executorScope: CoroutineScope
     private var averageProcessingTime: Long = 0
@@ -74,14 +77,16 @@ class OrderPayer {
         }
 
         executorScope.launch {
-            val createdEvent = paymentESService.create {
-                it.create(
-                    paymentId,
-                    orderId,
-                    amount
-                )
+            paymentEventWriter.submit(paymentId) {
+                val createdEvent = paymentESService.create {
+                    it.create(
+                        paymentId,
+                        orderId,
+                        amount
+                    )
+                }
+                logger.trace("Payment ${createdEvent.paymentId} for order $orderId created.")
             }
-            logger.trace("Payment ${createdEvent.paymentId} for order $orderId created.")
 
             paymentService.submitPaymentRequest(paymentId, amount, createdAt, deadline)
         }

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -64,7 +64,7 @@ class OrderPayer {
             .minOf { properties -> properties.parallelRequests }
         rateLimiter =
             LeakingBucketRateLimiter(
-                rate = 4000,
+                rate = 5000,
                 window = Duration.ofMillis(1000),
                 bucketSize = 5000
             )

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -47,14 +47,15 @@ class OrderPayer {
     @PostConstruct
     private fun initialize() {
         paymentExecutor = ThreadPoolExecutor(
-            16,
-            16,
+            50,
+            50,
             0L,
             TimeUnit.MILLISECONDS,
             LinkedBlockingQueue(10_000),
             NamedThreadFactory("payment-submission-executor"),
             CallerBlockingRejectedExecutionHandler()
         )
+        paymentExecutor.prestartAllCoreThreads()
         executorScope = CoroutineScope(paymentExecutor.asCoroutineDispatcher())
         averageProcessingTime = paymentService.getAllAccountProperties()
             .maxOf { properties -> properties.averageProcessingTime.toMillis() }
@@ -79,11 +80,7 @@ class OrderPayer {
         executorScope.launch {
             paymentEventWriter.submit(paymentId) {
                 val createdEvent = paymentESService.create {
-                    it.create(
-                        paymentId,
-                        orderId,
-                        amount
-                    )
+                    it.create(paymentId, orderId, amount)
                 }
                 logger.trace("Payment ${createdEvent.paymentId} for order $orderId created.")
             }

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -3,7 +3,7 @@ package ru.quipy.payments.logic
 import jakarta.annotation.PostConstruct
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -61,19 +61,19 @@ class OrderPayer {
             .minOf { properties -> properties.parallelRequests }
         rateLimiter =
             LeakingBucketRateLimiter(
-                rate = 1100,
+                rate = 4000,
                 window = Duration.ofMillis(1000),
-                bucketSize = 20000
+                bucketSize = 5000
             )
     }
 
     suspend fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
         val createdAt = System.currentTimeMillis()
         if (!rateLimiter.tick()) {
-            throw TooManyRequestsError(10000)
+            throw TooManyRequestsError(50)
         }
 
-        executorScope.async {
+        executorScope.launch {
             val createdEvent = paymentESService.create {
                 it.create(
                     paymentId,

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -12,6 +12,7 @@ import ru.quipy.common.utils.CallerBlockingRejectedExecutionHandler
 import ru.quipy.common.utils.LeakingBucketRateLimiter
 import ru.quipy.common.utils.NamedThreadFactory
 import ru.quipy.common.utils.RateLimiter
+import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
 import java.time.Duration
@@ -63,12 +64,10 @@ class OrderPayer {
             .minOf { properties -> properties.rateLimitPerSec }
         parallelRequests = paymentService.getAllAccountProperties()
             .minOf { properties -> properties.parallelRequests }
-        rateLimiter =
-            LeakingBucketRateLimiter(
-                rate = 5000,
-                window = Duration.ofMillis(1000),
-                bucketSize = 5000
-            )
+        rateLimiter = SlidingWindowRateLimiter(
+            5000,
+            Duration.ofSeconds(1)
+        )
     }
 
     suspend fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentEventWriter.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentEventWriter.kt
@@ -1,0 +1,27 @@
+package ru.quipy.payments.logic
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+@Component
+class PaymentEventWriter() {
+    private val mutexes = ConcurrentHashMap<UUID, Mutex>()
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    suspend fun submit(paymentId: UUID, block: () -> Unit) {
+        val mutex = mutexes.computeIfAbsent(paymentId) { Mutex() }
+
+        mutex.withLock {
+            try {
+                block()
+            } catch (e: Exception) {
+                logger.error("write failed for $paymentId", e)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentEventWriter.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentEventWriter.kt
@@ -14,8 +14,8 @@ import kotlin.math.abs
 class PaymentEventWriter() {
     private val logger = LoggerFactory.getLogger(PaymentEventWriter::class.java)
 
-    private val shards = 400
-    private val queuePerShard = 20000
+    private val shards = 500
+    private val queuePerShard = 10000
 
     private val channels = Array(shards) { Channel<suspend () -> Unit>(queuePerShard) }
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentEventWriter.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentEventWriter.kt
@@ -1,27 +1,46 @@
 package ru.quipy.payments.logic
 
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import java.util.UUID
-import java.util.concurrent.ConcurrentHashMap
 
 @Component
 class PaymentEventWriter() {
-    private val mutexes = ConcurrentHashMap<UUID, Mutex>()
+    private val logger = LoggerFactory.getLogger(PaymentEventWriter::class.java)
 
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val shards = 64
+    private val queuePerShard = 8192
 
-    suspend fun submit(paymentId: UUID, block: () -> Unit) {
-        val mutex = mutexes.computeIfAbsent(paymentId) { Mutex() }
+    private val channels = Array(shards) { Channel<suspend () -> Unit>(queuePerShard) }
 
-        mutex.withLock {
-            try {
-                block()
-            } catch (e: Exception) {
-                logger.error("write failed for $paymentId", e)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    init {
+        repeat(shards) { shard ->
+            scope.launch {
+                for (action in channels[shard]) {
+                    try {
+                        action()
+                    } catch (e: Exception) {
+                        logger.error("Shard $shard failed to process event", e)
+                    }
+                }
             }
         }
+    }
+
+    suspend fun submit(paymentId: UUID, block: () -> Unit) {
+        val shard = shardIndex(paymentId)
+        channels[shard].send(block)
+    }
+
+    private fun shardIndex(id: UUID): Int {
+        val h = id.mostSignificantBits xor id.leastSignificantBits
+        return (h and 0x7FFF_FFFF).toInt() % shards
     }
 }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentEventWriter.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentEventWriter.kt
@@ -8,13 +8,14 @@ import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import java.util.UUID
+import kotlin.math.abs
 
 @Component
 class PaymentEventWriter() {
     private val logger = LoggerFactory.getLogger(PaymentEventWriter::class.java)
 
-    private val shards = 64
-    private val queuePerShard = 8192
+    private val shards = 400
+    private val queuePerShard = 20000
 
     private val channels = Array(shards) { Channel<suspend () -> Unit>(queuePerShard) }
 
@@ -22,7 +23,7 @@ class PaymentEventWriter() {
 
     init {
         repeat(shards) { shard ->
-            scope.launch {
+            scope.launch(Dispatchers.IO) {
                 for (action in channels[shard]) {
                     try {
                         action()
@@ -34,13 +35,13 @@ class PaymentEventWriter() {
         }
     }
 
-    suspend fun submit(paymentId: UUID, block: () -> Unit) {
+    suspend fun submit(paymentId: UUID, block: suspend () -> Unit) {
         val shard = shardIndex(paymentId)
         channels[shard].send(block)
     }
 
     private fun shardIndex(id: UUID): Int {
         val h = id.mostSignificantBits xor id.leastSignificantBits
-        return (h and 0x7FFF_FFFF).toInt() % shards
+        return abs(h.toInt()) % shards
     }
 }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -5,10 +5,10 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.future.await
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import org.slf4j.LoggerFactory
@@ -70,7 +70,7 @@ class PaymentExternalSystemAdapterImpl(
     private val httpExecutorScope = CoroutineScope(httpExecutor.asCoroutineDispatcher())
 
     private val client = HttpClient.newBuilder()
-        .executor(Executors.newFixedThreadPool(100))
+        .executor(Executors.newFixedThreadPool(2000))
         .version(HttpClient.Version.HTTP_2)
         .build()
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -36,7 +36,8 @@ class PaymentExternalSystemAdapterImpl(
     private val paymentESService: EventSourcingService<UUID, PaymentAggregate, PaymentAggregateState>,
     private val paymentProviderHostPort: String,
     private val token: String,
-    promRegistry: MeterRegistry
+    private val paymentEventWriter: PaymentEventWriter,
+    promRegistry: MeterRegistry,
 ) : PaymentExternalSystemAdapter {
 
     companion object {
@@ -89,8 +90,10 @@ class PaymentExternalSystemAdapterImpl(
 
         // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
         // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
-        paymentESService.update(paymentId) {
-            it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
+        paymentEventWriter.submit(paymentId) {
+            paymentESService.update(paymentId) {
+                it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
+            }
         }
 
         logger.info("[$accountName] Submit: $paymentId , txId: $transactionId, amount: $amount")
@@ -122,8 +125,10 @@ class PaymentExternalSystemAdapterImpl(
 
                     if (success) {
                         logger.warn("[$accountName] [OK] txId=$transactionId payment=$paymentId")
-                        paymentESService.update(paymentId) {
-                            it.logProcessing(true, now(), transactionId, reason = body.message)
+                        paymentEventWriter.submit(paymentId) {
+                            paymentESService.update(paymentId) {
+                                it.logProcessing(true, now(), transactionId, reason = body.message)
+                            }
                         }
                         requestLatency.record((now() - start).toDouble())
                         return
@@ -146,8 +151,10 @@ class PaymentExternalSystemAdapterImpl(
                     }
 
                     logger.warn("[$accountName] [FAIL] txId=$transactionId payment=$paymentId code=$code msg=${body.message}")
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(false, now(), transactionId, reason = body.message ?: "Failed")
+                    paymentEventWriter.submit(paymentId) {
+                        paymentESService.update(paymentId) {
+                            it.logProcessing(false, now(), transactionId, reason = body.message ?: "Failed")
+                        }
                     }
                     requestLatency.record((now() - start).toDouble())
                 } catch (ex: Exception) {
@@ -166,8 +173,10 @@ class PaymentExternalSystemAdapterImpl(
                     }
 
                     logger.error("[$accountName] [ERROR] txId=$transactionId payment=$paymentId", ex)
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(false, now(), transactionId, reason = ex.message)
+                    paymentEventWriter.submit(paymentId) {
+                        paymentESService.update(paymentId) {
+                            it.logProcessing(false, now(), transactionId, reason = ex.message)
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -7,7 +7,7 @@ import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
@@ -50,7 +50,11 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
     private val price = properties.price
-    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong(), Duration.ofSeconds(1))
+    private val retryAfter = 50L
+    private val rateLimiter = SlidingWindowRateLimiter(
+        rateLimitPerSec.toLong(),
+        Duration.ofSeconds(1)
+    )
     private val semaphore = Semaphore(parallelRequests)
 
     private val httpExecutor = ThreadPoolExecutor(
@@ -62,7 +66,7 @@ class PaymentExternalSystemAdapterImpl(
         NamedThreadFactory("http-executor"),
         CallerBlockingRejectedExecutionHandler()
     )
-    private val httpExecutorScope = CoroutineScope(httpExecutor.asCoroutineDispatcher());
+    private val httpExecutorScope = CoroutineScope(httpExecutor.asCoroutineDispatcher())
 
     private val client = HttpClient.newBuilder()
         .executor(Executors.newFixedThreadPool(100))
@@ -130,10 +134,10 @@ class PaymentExternalSystemAdapterImpl(
 
                     if (retriableCode && attempt < maxRetries && timeLeft > avgProcMs && isBeneficial) {
                         retryCounterMetric.increment()
-                        val retryAfterMs = (500L * (1L shl attempt))
+                        val retryAfterMs = (retryAfter * (1L shl attempt))
                         logger.warn("[$accountName] [RETRY] txId=$transactionId payment=$paymentId will retry after $retryAfterMs ms.")
                         scheduler.schedule(
-                            { httpExecutorScope.async { attemptCall(attempt + 1) } },
+                            { httpExecutorScope.launch { attemptCall(attempt + 1) } },
                             retryAfterMs,
                             TimeUnit.MILLISECONDS
                         )
@@ -150,11 +154,11 @@ class PaymentExternalSystemAdapterImpl(
                     val isTimeout = ex is SocketTimeoutException
                     val timeLeft = deadline - now()
 
-                    if (isTimeout && attempt < maxRetries && timeLeft > avgProcMs + 500 && isBeneficial) {
+                    if (isTimeout && attempt < maxRetries && timeLeft > avgProcMs + retryAfter && isBeneficial) {
                         retryCounterMetric.increment()
-                        val retryAfterMs = (500L * (1L shl attempt))
+                        val retryAfterMs = (retryAfter * (1L shl attempt))
                         scheduler.schedule(
-                            { httpExecutorScope.async { attemptCall(attempt + 1) } },
+                            { httpExecutorScope.launch { attemptCall(attempt + 1) } },
                             retryAfterMs,
                             TimeUnit.MILLISECONDS
                         )
@@ -169,7 +173,7 @@ class PaymentExternalSystemAdapterImpl(
             }
         }
 
-        httpExecutorScope.async { attemptCall(0) }
+        httpExecutorScope.launch { attemptCall(0) }
     }
 
     override fun price() = properties.price


### PR DESCRIPTION
До: http://77.234.215.138:33000/d/KVr-Vmpnz/services-statistic?orgId=1&from=2026-02-17T20:06:16.474Z&to=2026-02-17T20:30:34.961Z&timezone=browser&var-service=M3401-9&refresh=5s
<img width="1280" height="302" alt="image" src="https://github.com/user-attachments/assets/b981867a-d510-43ec-b977-8902b2ddbadb" />
Очевидна разница I_PAYMENT_STARTED ~ 4K, I_STARTED_PAYMENT ~ 1K. Выставила несколько метрик для локализации проблемы:
<img width="1280" height="431" alt="image" src="https://github.com/user-attachments/assets/be627cc0-531e-4a5f-82c9-ffd035d2890b" />
В OrderPayer происходит сильное проседание. Там есть два потенциально проблемных места: rateLimiter и paymentESService. Поскольку rateLimiter полностью контролируем и гарантированно пропускает нужное число операций, обращаем внимание на доступ к БД, а именно хотим сделать его асинхронным.

После: http://77.234.215.138:33000/d/KVr-Vmpnz/services-statistic?orgId=1&from=2026-03-12T13:43:09.000Z&to=2026-03-12T13:50:24.835Z&timezone=browser&var-service=M3401-9&refresh=5s
<img width="2495" height="281" alt="image" src="https://github.com/user-attachments/assets/7921ff52-5a22-4428-b681-f42fc55bec89" />
